### PR TITLE
Fixed serious syntax issue

### DIFF
--- a/web/app/themes/jcio/base.php
+++ b/web/app/themes/jcio/base.php
@@ -6,22 +6,25 @@ use Roots\Sage\Wrapper;
 ?>
 <!doctype html>
 <html class="no-js" <?php language_attributes(); ?>>
-  <body <?php body_class(); ?>>
-    <?php
-      do_action('get_header');
-      get_header();
-    ?>
-    <div id="contentwrapper">
-      <?php get_template_part('templates/main-menu'); ?>
-      <a id="skipnav" name="skipnav"></a>
-      <div id="content">
+<head>
+    <?php get_template_part('head'); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php
+do_action('get_header');
+get_header();
+?>
+<div id="contentwrapper">
+    <?php get_template_part('templates/main-menu'); ?>
+    <a id="skipnav" name="skipnav"></a>
+    <div id="content">
         <?php include Wrapper\template_path(); ?>
-      </div>
     </div>
-    <?php
-      do_action('get_footer');
-      get_footer();
-      wp_footer();
-    ?>
-  </body>
+</div>
+<?php
+do_action('get_footer');
+get_footer();
+wp_footer();
+?>
+</body>
 </html>

--- a/web/app/themes/jcio/head.php
+++ b/web/app/themes/jcio/head.php
@@ -1,5 +1,5 @@
-<head>
+
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <?php wp_head(); ?>
-</head>
+

--- a/web/app/themes/jcio/header.php
+++ b/web/app/themes/jcio/header.php
@@ -1,23 +1,25 @@
-<?php get_template_part('head'); ?>
-<div id="cookieDirective" style="display:none;"></div><a accesskey="s" href="#skipnav" class="skip" title="Skip Navigation">Skip Navigation</a>
+
+<div id="cookieDirective" style="display:none;"></div>
+<a accesskey="s" href="#skipnav" class="skip" title="Skip Navigation">Skip Navigation</a>
 
 <div id="headerwrapper">
-  <div id="header">
-    <a href="<?php echo esc_url(home_url('/')); ?>"><img src="<?php echo \Roots\Sage\Assets\asset_path('images/logo-purple.png'); ?>" alt="<?php bloginfo('name'); ?>" /></a>
-  </div><!-- end header -->
+    <div id="header">
+        <a href="<?php echo esc_url(home_url('/')); ?>"><img
+                src="<?php echo \Roots\Sage\Assets\asset_path('images/logo-purple.png'); ?>"
+                alt="<?php bloginfo('name'); ?>"/></a>
+    </div><!-- end header -->
 </div><!-- end mainheader -->
 
 <!-- Breadcrumb -->
 <div id="breadcrumbwrapper">
-  <div id="breadcrumb">
-    <div class="breadcrumbs" xmlns:v="http://rdf.data-vocabulary.org/#">
-      <?php
-      if (function_exists('bcn_display') && !is_front_page())
-      {
-        bcn_display();
-      }
-      ?>
-    </div>
-  </div><!-- end breadcrumb -->
+    <div id="breadcrumb">
+        <div class="breadcrumbs" xmlns:v="http://rdf.data-vocabulary.org/#">
+            <?php
+            if (function_exists('bcn_display') && !is_front_page()) {
+                bcn_display();
+            }
+            ?>
+        </div>
+    </div><!-- end breadcrumb -->
 
 </div><!-- end breadcrumbwrapper -->


### PR DESCRIPTION
While testing the analytics on this site the plugin I use to test reported 'code found outside head tag'. When I investigated I noticed that the following files were causing the body tag to wrap the head which (in some cases) would prevent JS from operating properly, including the analytics.

        modified:   web/app/themes/jcio/base.php
        modified:   web/app/themes/jcio/head.php
        modified:   web/app/themes/jcio/header.php

This release fixed this syntax issue.